### PR TITLE
Initialize adaptive-π Platonic catalogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# venv
+.venv/
+# Python
+__pycache__/
+*.pyc
+# Outputs
+outputs/
+# OS
+.DS_Store
+Thumbs.db

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+title: Adaptive-π Platonic Catalogue
+message: "If you use this repository, please cite it as below."
+authors:
+  - family-names: McKenna
+    given-names: Ryan
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+version: "0.1.0"
+date-released: "2025-08-15"
+repository-code: "https://github.com/rdm3dc/adaptive-pi-platonic"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ryan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,80 @@
-That reply is solid. Here’s the precise math you can use (copy-ready), plus a short X reply you can post.
+# Adaptive-π Platonic Catalogue
 
-⸻
+**One-liner:** A tiny research repo showing how an adaptive π framework expands the classical Platonic catalogue.  
+We encode the existence rule with the π-ratio ρ := π_v / π_f and test which regular `{n,q}` pairs satisfy
+`1/n + (ρ/q) > 1/2`.
 
-Core formulas
+---
 
-Given a regular {n,q} object (n-gons, q meet at each vertex) with adaptive π, let
-\rho := \pi_a(\text{vertex}) / \pi_a(\text{face}).
-	1.	Vertex angle deficit (positivity = finite curvature at vertex):
-\delta \;=\; 2\,\pi_a(\text{vertex}) \;-\; q\Big(1-\tfrac{2}{n}\Big)\pi_a(\text{face})
-\;=\; 2\,\pi_a(\text{face})\Big[\rho \;-\; \tfrac{q}{2}\Big(1-\tfrac{2}{n}\Big)\Big].
-	2.	Deficit > 0 condition (the “master” closure):
-\[
-\rho \;>\; \rho^\(n,q), \quad\text{where}\quad
-\rho^\(n,q) \;=\; q\Big(\tfrac{1}{2}-\tfrac{1}{n}\Big).
-\]
-	3.	Specialize to \{3,7\}:
-\[
-\rho^\*(3,7) \;=\; 7\Big(\tfrac{1}{2}-\tfrac{1}{3}\Big)\;=\;\tfrac{7}{6}\;\approx\;1.166666\ldots
-\]
-\frac{\delta}{2\,\pi_a(\text{face})} \;=\; \rho - \tfrac{7}{6}.
-So at \rho=1.17 you’re on the boundary; at \rho=1.20,
-\delta/(2\pi_a(\text{face})) = 0.0333 (a clean 3.33% surplus).
+## Key idea
 
-⸻
+- Interior angle (regular n-gon): `θ_n(π_a) = (1 - 2/n) · π_a`
+- Vertex closure (q meet at each vertex): `q · θ_n(π_f) < 2 · π_v`
+- Define `ρ := π_v / π_f`  →  **Master inequality:**  
+  **`1/n + (ρ / q) > 1/2`**
 
-Euler characteristic (finite counts)
+Angle deficit (per vertex):  
+`δ = 2π_f [ ρ − ρ*(n,q) ]`, where `ρ*(n,q) = q (1/2 − 1/n) = q(n−2)/(2n)`.
 
-Combinatorics is topology-only (independent of π). With nF=2E, qV=2E, and V-E+F=\chi (χ is Euler characteristic):
+### Euclidean recovery
+If `ρ = 1` we get the classical condition `1/n + 1/q > 1/2` → exactly five Platonic solids.
 
-E \;=\; \frac{\chi}{-1 + \tfrac{2}{n} + \tfrac{2}{q}}
-\;=\; \frac{\chi}{\,2\big(\tfrac{1}{n}+\tfrac{1}{q}-\tfrac{1}{2}\big)}.
-F=\frac{2E}{n}, \qquad V=\frac{2E}{q}.
-	•	For a sphere (genus 0, \chi=2), finiteness requires \tfrac{1}{n}+\tfrac{1}{q}>\tfrac{1}{2}.
-That’s why only the classical five Platonic solids exist on genus 0.
-	•	For \{3,7\}, \tfrac{1}{3}+\tfrac{1}{7}-\tfrac{1}{2}=-\tfrac{1}{42}.
-On a genus g\ge 2 surface (\chi=2-2g<0) you get finite counts:
-E=42\,(g-1),\quad F=28\,(g-1),\quad V=12\,(g-1).
-Examples:
-g=2:\ (V,E,F)=(12,42,28).
-g=3:\ (24,84,56) — the classic \{3,7\} regular map on the Klein quartic.
+### Example
+`{3,7}` needs `ρ > 7/6 ≈ 1.1667`.  
+At `ρ = 1.20` the normalized surplus is `δ/(2π_f) = 1.20 − 1.1667 ≈ 0.0333` (3.33%).
 
-So: \rho>7/6 gives positive local angle deficit, but a finite, perfectly regular \{3,7\} object must live on genus g\ge2 (not a convex sphere). That’s your “triangular heptahedron” as a regular map on a higher-genus surface.
+---
 
-⸻
+## What’s in this repo
 
-A simple \pi_a model (text form)
+- `src/closure.py` — Core math utilities (ρ*, feasibility tests, counts).
+- `src/generate_tables.py` — Prints admissible `{n,q}` for a chosen ρ (and basic topology notes).
+- `src/render_ngon_star.py` — Saves a **PNG** of a simple `{n,q}` “star” patch (no OBJ).
+- `src/phase_diagram.py` — Saves a **PNG** heatmap showing which `{n,q}` are enabled at a given ρ.
+- `src/equations_card.py` — Saves a **PNG** card with the core equations (for posts/figures).
 
-Small-circle expansion under Gaussian curvature K at scale r:
-\pi_a(r)\;\approx\;\pi\Big(1-\frac{K\,r^2}{6}\Big).
-Then
-\rho \;=\; \frac{\pi_a(r_v)}{\pi_a(r_f)}
-\;\approx\; \frac{1-\frac{K r_v^2}{6}}{1-\frac{K r_f^2}{6}}
-\;\approx\; 1 + \frac{K}{6}\,(r_f^2 - r_v^2) \quad (\text{to first order}).
-Targeting \rho=1.2 gives K\,(r_f^2 - r_v^2)\approx 1.2.
-(If that’s outside the small-r regime, use a higher-order or alternative \pi_a law; \rho is still the right control parameter.)
+Outputs are written to `outputs/`.
 
-⸻
+---
+
+## Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+
+Quick start
+    1.List admissible {n,q} at ρ=1.20:
+
+python src/generate_tables.py --rho 1.20 --nmax 20 --qmax 20
+
+    2.Render a {3,7} PNG (no OBJ):
+
+python src/render_ngon_star.py --n 3 --q 7 --outfile outputs/ngon_3_7.png
+
+    3.Phase diagram at ρ=1.20:
+
+python src/phase_diagram.py --rho 1.20 --nmax 20 --qmax 20 --outfile outputs/phase_rho_1_20.png
+
+    4.Equation card PNG:
+
+python src/equations_card.py --outfile outputs/adaptive_pi_equations.png
+```
+
+---
+
+Notes on topology
+
+Combinatorics is π-independent. With nF=2E, qV=2E, and V−E+F=χ, a sphere (χ=2) requires
+1/n + 1/q > 1/2. Pairs with 1/n + 1/q ≤ 1/2 live as regular maps on tori or higher-genus surfaces.
+
+---
+
+Citation
+
+If you use this idea, please cite:
+
+McKenna, R. (RDM3DC). Adaptive-π vertex closure and the expanded Platonic catalogue (2025). GitHub: rdm3dc/adaptive-pi-platonic
+
+(You can also edit CITATION.cff with your author details.)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib

--- a/src/closure.py
+++ b/src/closure.py
@@ -1,0 +1,36 @@
+# src/closure.py
+import math
+from typing import List, Tuple
+
+
+def rho_star(n: int, q: int) -> float:
+    """Threshold ρ* = q (1/2 - 1/n) = q (n-2)/(2n)."""
+    return q * (0.5 - 1.0/n)
+
+
+def feasible(n: int, q: int, rho: float) -> bool:
+    """Master inequality: 1/n + (rho/q) > 1/2."""
+    return (1.0/n) + (rho / q) > 0.5
+
+
+def delta_normalized(n: int, q: int, rho: float) -> float:
+    """δ / (2π_f) = ρ − ρ*."""
+    return rho - rho_star(n, q)
+
+
+def euler_counts(n: int, q: int, chi: int) -> Tuple[int, int, int]:
+    """
+    E = chi / [ 2 (1/n + 1/q - 1/2) ]
+    F = 2E / n,  V = 2E / q
+    Returns (V, E, F). Values are integers if chi is compatible with (n,q).
+    """
+    denom = 2.0 * ((1.0/n) + (1.0/q) - 0.5)
+    E = chi / denom
+    V = 2.0 * E / q
+    F = 2.0 * E / n
+    return int(round(V)), int(round(E)), int(round(F))
+
+
+def genus_from_chi(chi: int) -> int:
+    """For orientable closed surfaces: chi = 2 - 2g  -> g = (2 - chi)/2."""
+    return (2 - chi) // 2

--- a/src/equations_card.py
+++ b/src/equations_card.py
@@ -1,0 +1,49 @@
+# src/equations_card.py
+import argparse
+import matplotlib.pyplot as plt
+
+CARD = r"""
+Adaptive-π Vertex Closure (Cheat Sheet)
+
+1) π_a small-circle (Gaussian curvature K at scale r):
+   π_a(r) ≈ π · (1 − K r² / 6)
+
+2) Interior angle (regular n-gon):
+   θ_n(π_a) = (1 − 2/n) · π_a
+
+3) Closure (q meet at a vertex):
+   q · θ_n(π_f) < 2 · π_v
+
+4) π-ratio:
+   ρ := π_v / π_f
+
+5) Master inequality:
+   1/n + (ρ / q) > 1/2
+
+6) Threshold:
+   ρ*(n,q) = q (1/2 − 1/n) = q (n−2) / (2n)
+
+7) Angle deficit:
+   δ = 2π_f [ ρ − ρ*(n,q) ]
+
+8) Euler (topology):
+   nF = 2E, qV = 2E,  V − E + F = χ
+   E = χ / ( 2 (1/n + 1/q − 1/2) )
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outfile", type=str, default="outputs/adaptive_pi_equations.png")
+    args = ap.parse_args()
+
+    fig, ax = plt.subplots(figsize=(8,6))
+    ax.axis('off')
+    ax.text(0.0, 1.0, CARD, va="top", fontsize=12, family="monospace")
+    fig.tight_layout()
+    fig.savefig(args.outfile, dpi=220, bbox_inches="tight")
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/generate_tables.py
+++ b/src/generate_tables.py
@@ -1,0 +1,26 @@
+# src/generate_tables.py
+import argparse
+from closure import feasible, rho_star, delta_normalized
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rho", type=float, required=True, help="π-ratio ρ = π_v/π_f")
+    ap.add_argument("--nmax", type=int, default=20)
+    ap.add_argument("--qmax", type=int, default=20)
+    args = ap.parse_args()
+
+    rho = args.rho
+    print(f"# Admissible {{n,q}} for ρ = {rho:.4f}  (condition: 1/n + ρ/q > 1/2)\n")
+    print(f"{'n':>3} {'q':>3} {'ρ*':>8} {'δ/(2π_f)':>10}")
+    print("-"*30)
+    for n in range(3, args.nmax+1):
+        for q in range(3, args.qmax+1):
+            if feasible(n, q, rho):
+                rs = rho_star(n, q)
+                dn = delta_normalized(n, q, rho)
+                print(f"{n:3d} {q:3d} {rs:8.4f} {dn:10.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/phase_diagram.py
+++ b/src/phase_diagram.py
@@ -1,0 +1,37 @@
+# src/phase_diagram.py
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from closure import feasible
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rho", type=float, required=True)
+    ap.add_argument("--nmax", type=int, default=20)
+    ap.add_argument("--qmax", type=int, default=20)
+    ap.add_argument("--outfile", type=str, default="outputs/phase.png")
+    args = ap.parse_args()
+
+    nmax, qmax = args.nmax, args.qmax
+    Z = np.zeros((nmax-2, qmax-2), dtype=int)  # index 0 -> n=3
+
+    for i, n in enumerate(range(3, nmax+1)):
+        for j, q in enumerate(range(3, qmax+1)):
+            Z[i, j] = 1 if feasible(n, q, args.rho) else 0
+
+    fig, ax = plt.subplots(figsize=(7,6))
+    im = ax.imshow(Z, origin='lower', aspect='auto', interpolation='nearest')
+    ax.set_xlabel("q (faces at vertex)")
+    ax.set_ylabel("n (gon sides)")
+    ax.set_xticks(np.arange(0, qmax-2, 2), labels=[str(q) for q in range(3, qmax+1, 2)])
+    ax.set_yticks(np.arange(0, nmax-2, 2), labels=[str(n) for n in range(3, nmax+1, 2)])
+    ax.set_title(f"Existence map at ρ = {args.rho}")
+    fig.colorbar(im, ax=ax, label="feasible (1=yes, 0=no)")
+    fig.tight_layout()
+    fig.savefig(args.outfile, dpi=220, bbox_inches="tight")
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/render_ngon_star.py
+++ b/src/render_ngon_star.py
@@ -1,0 +1,40 @@
+# src/render_ngon_star.py
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def render_ngon_star(n: int, q: int, R: float = 1.0, outfile: str = "outputs/ngon_star.png"):
+    """
+    Draws a simple 2D patch: q regular n-gons meeting at a central vertex.
+    This is a schematic visualization, not a geometric proof.
+    """
+    fig, ax = plt.subplots(figsize=(6,6))
+    # Each "n-gon" here is represented by an isosceles wedge approximating one face at the central vertex.
+    for k in range(q):
+        a0 = 2*np.pi * k / q
+        a1 = 2*np.pi * (k+1) / q
+        # triangles/wedges around the center
+        ax.fill([0, R*np.cos(a0), R*np.cos(a1)],
+                [0, R*np.sin(a0), R*np.sin(a1)],
+                facecolor='lightsteelblue', edgecolor='k', linewidth=0.8)
+
+    ax.set_aspect('equal')
+    ax.axis('off')
+    ax.set_title(f"Schematic patch for {{{n},{q}}}", fontsize=14)
+    fig.tight_layout()
+    fig.savefig(outfile, dpi=220, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, required=True)
+    ap.add_argument("--q", type=int, required=True)
+    ap.add_argument("--outfile", type=str, default="outputs/ngon_star.png")
+    args = ap.parse_args()
+    render_ngon_star(args.n, args.q, outfile=args.outfile)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Document adaptive-π framework and master inequality.
- Add core utilities for checking `{n,q}` feasibility and related scripts for tables, diagrams, and equation cards.
- Provide project metadata files including license, citation, and requirements.

## Testing
- `python src/generate_tables.py --rho 1.2 --nmax 5 --qmax 5`
- `python src/render_ngon_star.py --n 3 --q 7 --outfile outputs/ngon_3_7.png` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a0142898c4832fbc3ed58b38fe0130