### PR TITLE
Add CLI options for mode and rho in AdaptiveCAD driver

### DIFF
--- a/AdaptiveCAD/adaptive_pi/README_adaptive_pi.md
+++ b/AdaptiveCAD/adaptive_pi/README_adaptive_pi.md
@@ -16,7 +16,7 @@ enforces Gauss–Bonnet for genus 3, and renders a PNG.
 cd AdaptiveCAD
 python -m venv .venv && source .venv/bin/activate
 pip install numpy matplotlib
-python adaptive_pi/driver_adaptivecad.py
+python adaptive_pi/driver_adaptivecad.py --mode tempered --rho 1.7
 # -> outputs/adaptive_pi_K_genus3.png
 
 Wiring to your kernel
@@ -26,7 +26,8 @@ Replace the methods in KernelAdapter with your actual AdaptiveCAD API calls:
 • render_face_scalar() → your renderer to a PNG.
 
 Tweaks
-• Change rho_fn for spatially varying ρ(x).
+• Set `--rho` to pick a constant ρ in [1.3, 2.4].
+• Pass `--mode exact` to recover ρ from K via the exact sinh/sin laws (default `tempered`).
 • Switch branch to "spherical" and set r_f > r_v if you want a spherical variant.
 • Use your {3,7} combinatorics if you have it; this driver is geometry-first and PNG-only.
 


### PR DESCRIPTION
## Summary
- enable selecting rho recovery mode (`tempered` or `exact`) via `--mode`
- allow choosing constant rho field with `--rho` and range validation
- document new driver options in README

## Testing
- `python -m adaptive_pi.driver_adaptivecad --mode tempered --rho 1.7`
- `python -m adaptive_pi.driver_adaptivecad --mode exact --rho 1.7`
- `python -m adaptive_pi.driver_adaptivecad --help`


------
https://chatgpt.com/codex/tasks/task_e_68a027e8894c832f80c3609408339e31