### PR TITLE
Add AdaptiveCAD link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ At `ρ = 1.20` the normalized surplus is `δ/(2π_f) = 1.20 − 1.1667 ≈ 0.033
 
 Outputs are written to `outputs/`.
 
+For a CAD-focused implementation, see [AdaptiveCAD](https://github.com/RDM3DC/AdaptiveCAD).
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary
- mention AdaptiveCAD repository for CAD-focused implementation in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a02ae5c180832f9fb6ff929aadb1f2