### PR TITLE
Add sympy and pandas dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy
 matplotlib
+pandas
+sympy


### PR DESCRIPTION
## Summary
- Include `pandas` and `sympy` in requirements for 14-gon builder and Gauss–Bonnet verification scripts.

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python klein_domain_chi_from_pairings.py`
- `python klein_14gon_sympy_builder.py` *(fails: No module named 'sympy')*
- `python klein_euler_gb_verify.py klein_14gon_vertices.csv klein_14gon_faces.csv` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a032fb924c832fa19460f3fd2af415